### PR TITLE
Added condition in the AddiGelper.php class to only return the custom…

### DIFF
--- a/Controller/Callback/Index.php
+++ b/Controller/Callback/Index.php
@@ -200,6 +200,7 @@ class Index extends Action implements CsrfAwareActionInterface, HttpPostActionIn
             $status = $this->_addiHelper->getNewOrderStatus();
             $order->setStatus($status);
             $order->setState("processing");
+            $this->logger("ADDI UPDATED ORDER STATUS for Order ID " . $params->orderId . ": " . $status);
 
             $order->save();
         } catch (Exception $e) {

--- a/Helper/AddiHelper.php
+++ b/Helper/AddiHelper.php
@@ -12,6 +12,9 @@ class AddiHelper extends AbstractHelper
 {
     CONST WIDGET_VERSION_01 = 'ADDI_TEMPLATE_01';
     CONST WIDGET_VERSION_02 = 'ADDI_TEMPLATE_02';
+    CONST STATUS_POR_SINCRONIZAR = 'por_sincronizar';
+    CONST STATUS_PROCESSING = 'processing';
+
 
     /** @var Image */
     protected $_imageHelper;
@@ -87,7 +90,8 @@ class AddiHelper extends AbstractHelper
 
     public function getNewOrderStatus()
     {
-        return $this->scopeConfig->getValue("payment/addi/credentials/order_status", ScopeInterface::SCOPE_STORE);
+        $status = $this->scopeConfig->getValue("payment/addi/credentials/order_status", ScopeInterface::SCOPE_STORE);
+        return $status === self::STATUS_POR_SINCRONIZAR ? $status : self::STATUS_PROCESSING;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento 2 Payment Module",
     "type": "magento2-module",
     "license": "proprietary",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
Problem Description:

New allies attempting to utilize our Magento payment plugin extension encountered issues when receiving callback notifications regarding their payment/application results. Consequently, clients were not being correctly redirected to the appropriate pages: either the successful payment page or the checkout page in cases where the payment was rejected or canceled.

More context [here](https://www.notion.so/addico/Magento-plug-in-Sport-Line-08ca894962544150ba78e25a91af9d45)
