### PR TITLE
add complete status

### DIFF
--- a/Controller/Redirect/Index.php
+++ b/Controller/Redirect/Index.php
@@ -76,7 +76,7 @@ class Index extends AbstractAddi
                 $order->getStatus()
             );
 
-            if ($order->getStatus() == 'processing' || $order->getStatus() == 'por_sincronizar') {
+            if ($order->getStatus() == 'processing' || $order->getStatus() == 'por_sincronizar' || $order->getStatus() == 'complete' ) {
                 $this->_checkSession->setLastSuccessQuoteId($order->getQuoteId());
                 $this->_checkSession->setLastQuoteId($order->getQuoteId());
                 $this->_checkSession->setLastOrderId($order->getId());

--- a/Helper/AddiHelper.php
+++ b/Helper/AddiHelper.php
@@ -14,6 +14,7 @@ class AddiHelper extends AbstractHelper
     CONST WIDGET_VERSION_02 = 'ADDI_TEMPLATE_02';
     CONST STATUS_POR_SINCRONIZAR = 'por_sincronizar';
     CONST STATUS_PROCESSING = 'processing';
+    CONST STATUS_COMPLETE = 'complete';
 
 
     /** @var Image */
@@ -91,7 +92,7 @@ class AddiHelper extends AbstractHelper
     public function getNewOrderStatus()
     {
         $status = $this->scopeConfig->getValue("payment/addi/credentials/order_status", ScopeInterface::SCOPE_STORE);
-        return $status === self::STATUS_POR_SINCRONIZAR ? $status : self::STATUS_PROCESSING;
+        return $status === self::STATUS_POR_SINCRONIZAR ? $status : ($status === self::STATUS_COMPLETE ? self::STATUS_COMPLETE : self::STATUS_PROCESSING);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Magento 2 Payment Module",
     "type": "magento2-module",
     "license": "proprietary",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "minimum-stability": "stable",
     "prefer-stable": true,
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Addi_Payment" setup_version="1.0.10">
+	<module name="Addi_Payment" setup_version="1.0.20">
 		<sequence>
 			<module name="Magento_Sales"/>
 		</sequence>


### PR DESCRIPTION
For the ABBOT integration that has a problem with the client redirection we fix this error adding this new status 'complete' because is the status that they are using currently on their ecommerce